### PR TITLE
Add `npm run build` to travis ci script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,9 @@ node_js:
   - "9"
   - "8"
 
+script:
+  - npm run build
+  - npm test
+
 notifications:
   email: false


### PR DESCRIPTION
By default, travis ci runs just `npm test`. Now, the script runs both `npm run build` and `npm test` to ensure that the build is working properly.

Todo in the future: add actual tests to `test/` 😄 