### PR TITLE
Email Date Changes

### DIFF
--- a/templates/DigitalFuturesNewsletter1.njk
+++ b/templates/DigitalFuturesNewsletter1.njk
@@ -35,7 +35,7 @@
           <center>
             <a href="http://revolutionuc.com/" target="_blank">
               <img
-                src="https://assets.revolutionuc.com/email/revuc-logo-spring-2022.png"
+                src="https://assets.revolutionuc.com/email/revuc-logo-spring-2023.png"
                 alt="RevolutionUC logo"
                 width="150" height="175"
               />
@@ -47,7 +47,7 @@
       <row class="main">
         <column>
           <h1 class="main__header">
-            <a href="http://revolutionuc.com/" target="_blank">RevolutionUC - Spring 2022</a>
+            <a href="http://revolutionuc.com/" target="_blank">RevolutionUC - Spring 2023</a>
           </h1>
 
           {% block main %}{% endblock %}
@@ -125,7 +125,7 @@ Thank you for your involvement in the hackathon. Your participation and support 
 
           <p><a href="mailto:info@revolutionuc.com">Contact Us</a></p>
 
-          <p>© 2022 RevolutionUC</p>
+          <p>© 2023 RevolutionUC</p>
         </column>
       </row>
     </container>

--- a/templates/infoEmail1.njk
+++ b/templates/infoEmail1.njk
@@ -8,7 +8,7 @@
 {% block main %}
 <h1>Hey, {{ firstName if firstName else '{{first_name}}' }}!</h1>
 
-<p>We’re less than 3 weeks away from RevolutionUC Spring 2022! Here are some updates on the event:</p>
+<p>We’re less than 3 weeks away from RevolutionUC Spring 2023! Here are some updates on the event:</p>
 
 <h3>Attendance Confirmation</h3>
 <p>You will receive an attendance confirmation email early next week. If you are planning to participate in RevolutionUC, please make sure you confirm your attendance.</p>

--- a/templates/infoEmail2.njk
+++ b/templates/infoEmail2.njk
@@ -9,7 +9,7 @@
 {% block main %}
 <h1>Hey, {{ firstName if firstName else '{{first_name}}' }}!</h1>
 
-<p>We’re less than 2 weeks away from RevolutionUC Spring 2022! Here are some updates on the event:</p>
+<p>We’re less than 2 weeks away from RevolutionUC Spring 2023! Here are some updates on the event:</p>
 
 {% include dirname + '/partials/Lattice.njk' %}
 

--- a/templates/infoEmailJudges.njk
+++ b/templates/infoEmailJudges.njk
@@ -36,7 +36,7 @@ will resolve your issue. Once you are in, get acquainted with our channels!
 You can also view this <a href="https://support.discord.com/hc/en-us/articles/360045138571-Beginner-s-Guide-to-Discord" target="_blank"><t>link to learn how Discord works!</a>
 </p>
 
-<h3>Schedule (February 27, 2022)</h3>
+<h3>Schedule (February 27, 2023)</h3>
 <p>
 12:30pm EST - Meeting on Discord (#lounge voice channel) for updates and tech help. We will also be going over the judging portal and the judging process.
 <br>1:00pm EST  - Judging starts

--- a/templates/latticeResetPassword.njk
+++ b/templates/latticeResetPassword.njk
@@ -9,7 +9,7 @@
 {% block main %}
 <h1>Hey, {{ firstName if firstName else '{{first_name}}' }}!</h1>
 
-<p>We have received a password reset request for your Lattice account. Lattice is our Hacker matching app that you can use to find other RevolutionUC 2022 participants to team up with.<p>
+<p>We have received a password reset request for your Lattice account. Lattice is our Hacker matching app that you can use to find other RevolutionUC 2023 participants to team up with.<p>
 
 <p>Please use the link below to reset your Lattice password</p>
 

--- a/templates/marketingEmail.njk
+++ b/templates/marketingEmail.njk
@@ -1,7 +1,7 @@
 {% extends dirname + '/master.njk' %}
 
 {% block main %}
-<p>Hey Bearcats! We’re less than 4 weeks away from RevolutionUC Spring 2022!</p>
+<p>Hey Bearcats! We’re less than 4 weeks away from RevolutionUC Spring 2023!</p>
 
 <h3>General Information</h3>
 <p>RevolutionUC is UC’s 24-hour hackathon and it is happening virtually on February 20th and 21st! We are student-organized and a Major League Hacking-partnered hackathon, which means this tech event is catered specifically to you!</p>

--- a/templates/master.njk
+++ b/templates/master.njk
@@ -96,7 +96,7 @@
 
           <p><a href="mailto:info@revolutionuc.com">Contact Us</a></p>
 
-          <p>© 2022 RevolutionUC</p>
+          <p>© 2023 RevolutionUC</p>
         </column>
       </row>
     </container>

--- a/templates/partials/HackSubmissions.njk
+++ b/templates/partials/HackSubmissions.njk
@@ -1,2 +1,2 @@
 <p><strong>Hack Submission</strong><br />
-All projects must be submitted to Devpost to be considered for judging. Hacks must not be reused from other hackathons - only hacks started during RevolutionUC 2022 will be allowed. Stay tuned for more details on prizing categories and judging.</p>
+All projects must be submitted to Devpost to be considered for judging. Hacks must not be reused from other hackathons - only hacks started during RevolutionUC 2023 will be allowed. Stay tuned for more details on prizing categories and judging.</p>

--- a/templates/postEventEmail.njk
+++ b/templates/postEventEmail.njk
@@ -6,7 +6,7 @@
 <p>Thank you for attending RevolutionUC! Below is important information on the post event survey and prize information</p>
 
 <h3>Survey</h3>
-<p>What did you think of RevolutionUC 2022? Did you absolutely love something? How can we improve? Let us know in our post event survey below.
+<p>What did you think of RevolutionUC 2023? Did you absolutely love something? How can we improve? Let us know in our post event survey below.
 <br /><br />
 Any feedback you provide will help us to make the hackathon even better! All answers are anonymous and will be valuable in helping us plan for next year.</p>
 <button href="https://forms.gle/pXH62rk36R6xQbkJ6" target="_blank">Post Event Survey</button>

--- a/templates/postEventJudgeEmail.njk
+++ b/templates/postEventJudgeEmail.njk
@@ -6,7 +6,7 @@
 <p>Thank you for your help in making the first virtual AND international RevolutionUC great! Below is important information on requesting swag (as promised!) and a way for you to give us some feedback!</p>
 
 <h3>Survey</h3>
-<p>What did you think of RevolutionUC 2022? Did you absolutely love something? How can we improve? Let us know in our post event survey below.
+<p>What did you think of RevolutionUC 2023? Did you absolutely love something? How can we improve? Let us know in our post event survey below.
 <br /><br />
 Any feedback you provide will help us to make the hackathon even better! All answers are anonymous and will be valuable in helping us plan for next year.</p>
 <button href="https://forms.gle/HNttG4mqxq5DhBjF9" target="_blank">Post Event Survey</button>

--- a/templates/postEventSurveyReminder.njk
+++ b/templates/postEventSurveyReminder.njk
@@ -3,7 +3,7 @@
 
 {% block main %}
 <h1>Hey, {{ firstName if firstName else '{{first_name}}' }}!</h1>
-<p>A final reminder that we would love your feedback on your experience at RevolutionUC! What did you think of RevolutionUC 2022? Did you absolutely love something? How can we improve? Let us know in our post event survey below. Any feedback you provide will help us to make the hackathon even better! All answers are anonymous and will be valuable in helping us plan for next year.</p>
+<p>A final reminder that we would love your feedback on your experience at RevolutionUC! What did you think of RevolutionUC 2023? Did you absolutely love something? How can we improve? Let us know in our post event survey below. Any feedback you provide will help us to make the hackathon even better! All answers are anonymous and will be valuable in helping us plan for next year.</p>
 <button href="https://forms.gle/pXH62rk36R6xQbkJ6" target="_blank">Post Event Survey</button>
 
 <p>Once again, thank you for attending and see you next year!</p>

--- a/templates/registrationOpen.njk
+++ b/templates/registrationOpen.njk
@@ -8,7 +8,7 @@
 {% block main %}
 <h1>Hi, {{ firstName if firstName else '{{first_name}}' }}!</h1>
 
-<p>We’re excited to share that registration for RevolutionUC Spring 2022 is now open!</p>
+<p>We’re excited to share that registration for RevolutionUC Spring 2023 is now open!</p>
 
 <button href="http://revolutionuc.com/register/" target="_blank">Register Now</button>
 {% endblock %}

--- a/templates/waiverUpdate.njk
+++ b/templates/waiverUpdate.njk
@@ -4,6 +4,6 @@
 <p>Thank you for registering for RevolutionUC!</p>
 
 <p>
-  We have updated our waiver of liability for RevolutionUC 2022. The new waiver can be found here: <a href="https://revolutionuc.com/waiver">https://revolutionuc.com/waiver/</a>. By registering for RevolutionUC, you are accepting this waiver. If you have any questions or issues regarding the waiver, please reach out to us.
+  We have updated our waiver of liability for RevolutionUC 2023. The new waiver can be found here: <a href="https://revolutionuc.com/waiver">https://revolutionuc.com/waiver/</a>. By registering for RevolutionUC, you are accepting this waiver. If you have any questions or issues regarding the waiver, please reach out to us.
 </p>
 {% endblock %}


### PR DESCRIPTION
**_DigitalFuturesNewsletter1:_**
- Changed Spring 2022 to Spring 2023 in the Heading	         
- Changed year in the footer from 2022 to 2023                     
- Logo is changed to 2023 logo (Couldn’t check if it displays properly)?

**_infoEmail1, infoEmail2, latticeResetPassword, MarketingEmail, postEventEmail, postEventJudgeEmail, postEventSurveyReminder, registrationOpen, waiverUpdate:_**
- Changed 2022 to 2023 in the paragraph


**_infoEmailJudges:_**
- Changed Schedule date from 2022 to 2023                   


**_master:_**
- Changed footer from 2022 to 2023
